### PR TITLE
math: use Sincos instead of Sin and Cos in Jn and Yn

### DIFF
--- a/src/math/jn.go
+++ b/src/math/jn.go
@@ -103,15 +103,16 @@ func Jn(n int, x float64) float64 {
 			//                 3     s+c             c-s
 
 			var temp float64
+			tempSin, tempCos := Sincos(x)
 			switch n & 3 {
 			case 0:
-				temp = Cos(x) + Sin(x)
+				temp = tempCos + tempSin
 			case 1:
-				temp = -Cos(x) + Sin(x)
+				temp = -tempCos + tempSin
 			case 2:
-				temp = -Cos(x) - Sin(x)
+				temp = -tempCos - tempSin
 			case 3:
-				temp = Cos(x) - Sin(x)
+				temp = tempCos - tempSin
 			}
 			b = (1 / SqrtPi) * temp / Sqrt(x)
 		} else {
@@ -278,15 +279,16 @@ func Yn(n int, x float64) float64 {
 		//		   3	 s+c		 c-s
 
 		var temp float64
+		tempSin, tempCos := Sincos(x)
 		switch n & 3 {
 		case 0:
-			temp = Sin(x) - Cos(x)
+			temp = tempSin - tempCos
 		case 1:
-			temp = -Sin(x) - Cos(x)
+			temp = -tempSin - tempCos
 		case 2:
-			temp = -Sin(x) + Cos(x)
+			temp = -tempSin + tempCos
 		case 3:
-			temp = Sin(x) + Cos(x)
+			temp = tempSin + tempCos
 		}
 		b = (1 / SqrtPi) * temp / Sqrt(x)
 	} else {


### PR DESCRIPTION
This is conceptually simpler.

Benchmarks:

name                   old time/op  new time/op  delta
Acos-8                 13.5ns ± 0%  13.5ns ± 0%     ~     (all equal)
Acosh-8                18.6ns ± 0%  18.8ns ± 0%   +1.07%  (p=0.000 n=20+20)
Asin-8                 10.8ns ± 0%  10.8ns ± 0%     ~     (all equal)
Asinh-8                24.9ns ± 0%  24.9ns ± 0%     ~     (all equal)
Atan-8                 6.68ns ± 0%  6.68ns ± 0%     ~     (p=0.093 n=19+18)
Atanh-8                21.1ns ± 0%  21.1ns ± 0%   -0.17%  (p=0.008 n=20+20)
Atan2-8                12.7ns ± 0%  12.7ns ± 0%     ~     (all equal)
Cbrt-8                 11.5ns ± 0%  11.5ns ± 0%     ~     (all equal)
Ceil-8                 2.01ns ± 0%  2.01ns ± 0%     ~     (all equal)
Copysign-8             0.81ns ± 0%  0.81ns ± 0%     ~     (all equal)
Cos-8                  10.0ns ± 0%  10.3ns ± 0%   +3.00%  (p=0.000 n=19+20)
Cosh-8                 13.5ns ± 0%  13.5ns ± 0%     ~     (all equal)
Erf-8                  7.17ns ± 0%  7.17ns ± 0%     ~     (p=1.000 n=20+20)
Erfc-8                 8.29ns ± 0%  8.29ns ± 0%     ~     (all equal)
Erfinv-8               8.88ns ± 0%  8.89ns ± 0%   +0.07%  (p=0.000 n=19+20)
Erfcinv-8              8.89ns ± 0%  8.89ns ± 0%     ~     (all equal)
Exp-8                  8.55ns ± 0%  8.55ns ± 0%     ~     (all equal)
ExpGo-8                21.9ns ± 0%  21.9ns ± 0%     ~     (all equal)
Expm1-8                12.0ns ± 0%  12.0ns ± 0%     ~     (all equal)
Exp2-8                 20.8ns ± 0%  20.8ns ± 0%     ~     (p=0.187 n=16+18)
Exp2Go-8               21.1ns ± 1%  21.0ns ± 1%     ~     (p=0.505 n=19+16)
Abs-8                  0.57ns ± 1%  0.75ns ± 0%  +32.96%  (p=0.000 n=19+20)
Dim-8                  0.75ns ± 0%  0.75ns ± 0%     ~     (all equal)
Floor-8                2.01ns ± 0%  2.01ns ± 0%     ~     (all equal)
Max-8                  2.14ns ± 0%  2.14ns ± 0%     ~     (all equal)
Min-8                  2.27ns ± 1%  2.26ns ± 0%   -0.26%  (p=0.000 n=20+17)
Mod-8                  28.5ns ± 0%  28.2ns ± 0%   -1.05%  (p=0.000 n=15+19)
Frexp-8                4.01ns ± 0%  3.76ns ± 0%   -6.23%  (p=0.000 n=16+17)
Gamma-8                9.22ns ± 0%  9.22ns ± 0%     ~     (all equal)
Hypot-8                3.06ns ± 0%  3.06ns ± 0%     ~     (all equal)
HypotGo-8              5.47ns ± 0%  5.48ns ± 0%   +0.11%  (p=0.000 n=19+18)
Ilogb-8                3.51ns ± 0%  3.27ns ± 0%   -6.94%  (p=0.000 n=19+20)
J0-8                   51.7ns ± 0%  51.5ns ± 1%   -0.33%  (p=0.000 n=18+20)
J1-8                   50.9ns ± 0%  51.4ns ± 0%   +0.98%  (p=0.000 n=16+14)
Jn-8                    110ns ± 0%   110ns ± 0%     ~     (all equal)
Ldexp-8                5.73ns ± 1%  5.33ns ± 0%   -7.04%  (p=0.000 n=20+18)
Lgamma-8               11.4ns ± 0%  11.4ns ± 0%     ~     (all equal)
Log-8                  8.92ns ± 0%  8.92ns ± 0%     ~     (p=0.064 n=17+18)
Logb-8                 3.96ns ± 1%  4.02ns ± 0%   +1.49%  (p=0.000 n=19+16)
Log1p-8                13.4ns ± 0%  13.4ns ± 0%     ~     (all equal)
Log10-8                11.2ns ± 0%  11.2ns ± 0%     ~     (all equal)
Log2-8                 5.54ns ± 0%  5.52ns ± 0%   -0.44%  (p=0.000 n=20+19)
Modf-8                 3.26ns ± 0%  3.26ns ± 0%     ~     (all equal)
Nextafter32-8          3.08ns ± 1%  3.30ns ± 0%   +7.13%  (p=0.000 n=20+18)
Nextafter64-8          3.51ns ± 0%  2.80ns ± 1%  -20.10%  (p=0.000 n=19+20)
PowInt-8               24.4ns ± 0%  26.2ns ± 0%   +7.38%  (p=0.000 n=15+17)
PowFrac-8              67.7ns ± 0%  67.8ns ± 0%   +0.15%  (p=0.000 n=19+19)
Pow10Pos-8             1.00ns ± 0%  1.00ns ± 0%     ~     (all equal)
Pow10Neg-8             1.25ns ± 0%  1.25ns ± 0%     ~     (all equal)
Round-8                2.13ns ± 0%  2.13ns ± 0%     ~     (all equal)
RoundToEven-8          0.56ns ± 0%  0.56ns ± 0%     ~     (all equal)
Remainder-8            28.0ns ± 0%  26.2ns ± 0%   -6.43%  (p=0.000 n=18+18)
Signbit-8              0.50ns ± 0%  0.50ns ± 0%     ~     (p=1.000 n=20+20)
Sin-8                  9.29ns ± 0%  9.29ns ± 0%     ~     (p=1.000 n=20+20)
Sincos-8               11.6ns ± 0%  11.6ns ± 0%     ~     (all equal)
Sinh-8                 13.2ns ± 0%  13.2ns ± 0%     ~     (all equal)
SqrtIndirect-8         2.27ns ± 0%  2.26ns ± 0%   -0.44%  (p=0.000 n=16+20)
SqrtLatency-8          3.26ns ± 0%  3.26ns ± 0%     ~     (all equal)
SqrtIndirectLatency-8  5.77ns ± 0%  5.77ns ± 0%     ~     (all equal)
SqrtGoLatency-8        34.8ns ± 0%  33.9ns ± 0%   -2.59%  (p=0.000 n=16+18)
SqrtPrime-8            2.47µs ± 0%  2.56µs ± 0%   +3.37%  (p=0.000 n=19+19)
Tan-8                  9.63ns ± 0%  9.63ns ± 0%     ~     (all equal)
Tanh-8                 13.9ns ± 0%  13.9ns ± 0%     ~     (all equal)
Trunc-8                2.01ns ± 0%  2.01ns ± 0%     ~     (all equal)
Y0-8                   49.3ns ± 0%  49.5ns ± 0%   +0.50%  (p=0.000 n=20+19)
Y1-8                   49.4ns ± 0%  49.6ns ± 0%   +0.40%  (p=0.000 n=19+20)
Yn-8                    107ns ± 0%   107ns ± 0%     ~     (all equal)
Float64bits-8          0.50ns ± 0%  0.31ns ± 0%  -37.56%  (p=0.000 n=20+18)
Float64frombits-8      0.31ns ± 0%  0.50ns ± 1%  +61.25%  (p=0.000 n=19+18)
Float32bits-8          0.31ns ± 0%  0.50ns ± 0%  +60.06%  (p=0.000 n=19+19)
Float32frombits-8      0.50ns ± 1%  0.31ns ± 0%  -37.58%  (p=0.000 n=18+19)

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
